### PR TITLE
shell script to auto boot blueberry-pi

### DIFF
--- a/src/boot-blueberrypi.sh
+++ b/src/boot-blueberrypi.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# SUMMARY
+# This script boots up all the required blueberry-pi
+# processes to begin sending hand orientation data to 
+# the server.
+
+# EXECUTING
+# in command line, type the following:
+# ./boot-blueberrypi.sh
+
+# CONFIGURATIONS
+WIFI=./wifi
+
+# give permissions for the script to run on command line
+chmod +x boot-blueberrypi.sh
+
+# add all background processes here
+python3 $WIFI/sb_client.py &
+
+exit


### PR DESCRIPTION
- Run the script by opening a terminal in the blueberry-pi/src folder. 
- In the terminal, type ./boot-blueberrypi to auto run all python modules concurrently.